### PR TITLE
Ensure shortage calc ignores mismatched days

### DIFF
--- a/tests/test_shortage_column_alignment.py
+++ b/tests/test_shortage_column_alignment.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+from shift_suite.tasks.shortage import align_need_staff_columns
+
+
+def test_column_mismatch_excluded() -> None:
+    need_df = pd.DataFrame({"2024-06-01": [2], "2024-06-02": [2]})
+    staff_df = pd.DataFrame({"2024-06-01": [1], "2024-06-03": [1]})
+
+    inflated_total = (need_df.fillna(0) - staff_df.fillna(0)).clip(lower=0).sum().sum()
+
+    aligned_need, aligned_staff = align_need_staff_columns(need_df, staff_df)
+    fixed_total = (aligned_need - aligned_staff).clip(lower=0).sum().sum()
+
+    assert inflated_total == 3
+    assert fixed_total == 1
+    assert list(aligned_need.columns) == ["2024-06-01"]


### PR DESCRIPTION
## Summary
- Drop non-overlapping day columns between need and staff data before shortage calculation
- Warn when need and staff days differ and use only intersection of columns
- Add unit test covering mismatched day columns

## Testing
- `ruff check shift_suite/tasks/shortage.py tests/test_shortage_column_alignment.py`
- `PYTHONDONTWRITEBYTECODE=1 pytest -q` *(fails: import file mismatch; unable to run full suite)*

------
https://chatgpt.com/codex/tasks/task_e_689ec409d91c8333ae21a3f951d20620