### PR TITLE
Add period dependency precheck

### DIFF
--- a/test_period_precheck.py
+++ b/test_period_precheck.py
@@ -1,0 +1,18 @@
+import pandas as pd
+import logging
+from shift_suite.tasks.shortage import shortage_and_brief
+
+
+def test_period_precheck_trims(tmp_path, caplog):
+    dates = pd.date_range("2024-01-01", periods=365, freq="D")
+    cols = dates.strftime("%Y-%m-%d")
+    need_df = pd.DataFrame([1] * len(cols), index=["00:00"], columns=cols)
+    staff_df = pd.DataFrame([0] * len(cols), index=["00:00"], columns=cols)
+    need_df.to_parquet(tmp_path / "need_per_date_slot.parquet")
+    staff_df.to_parquet(tmp_path / "heat_ALL.parquet")
+    caplog.set_level(logging.WARNING)
+    shortage_and_brief(tmp_path, slot=60)
+    output = pd.read_parquet(tmp_path / "shortage_time.parquet")
+    warned = any("PERIOD_PRECHECK" in r.message for r in caplog.records)
+    assert warned
+    assert output.shape[1] < len(cols)


### PR DESCRIPTION
## Summary
- Add period dependency precheck in `shortage_and_brief` to warn or trim when analysis covers too many days
- Add regression test ensuring long-period datasets trigger the precheck and are trimmed

## Testing
- `ruff check shift_suite/tasks/shortage.py test_period_precheck.py`
- `pytest -q` *(fails: import file mismatch and missing app module in legacy tests)*


------
https://chatgpt.com/codex/tasks/task_e_689ecc41882c8333be2b3e1ece986c46