### PR TITLE
Correct need aggregation and supply actual counts for shortage display

### DIFF
--- a/app.py
+++ b/app.py
@@ -3991,7 +3991,7 @@ def display_shortage_tab(tab_container, data_dir):
             ):
                 with tab:
                     st.dataframe(
-                        scenario_df[["time_group", "職種", "雇用形態", "actual_count", col]],
+                        scenario_df[["time_group", "職種", "雇用形態", "actual_count", col]].drop_duplicates(),
                         use_container_width=True,
                     )
         df_s_role = display_data.get("shortage_role")

--- a/shift_suite/tasks/shortage.py
+++ b/shift_suite/tasks/shortage.py
@@ -2062,10 +2062,12 @@ def assign_shortage_to_individuals(
 
     merge_cols = ['time_group', '職種', '雇用形態']
     shortage_cols = ['shortage_mean', 'shortage_median', 'shortage_p25']
+    cols_to_add = ['actual_count'] + shortage_cols
+
     merged = df.merge(
-        shortage_df[merge_cols + shortage_cols],
+        shortage_df[merge_cols + cols_to_add],
         on=merge_cols,
         how='left'
-    ).fillna({col: 0 for col in shortage_cols})
+    ).fillna({col: 0 for col in cols_to_add})
 
     return merged

--- a/shift_suite/tasks/statistical_need_calculator.py
+++ b/shift_suite/tasks/statistical_need_calculator.py
@@ -19,19 +19,34 @@ def calculate_all_statistical_needs(
     df = actual_df.copy()
     freq = f"{time_unit_minutes}min"
 
-    # 時間単位で丸め、集計用のキーを作成
+    # 時間単位で丸め、時間帯情報を追加
     df['time_group'] = df['timestamp'].dt.floor(freq)
+    df['time_of_day'] = df['time_group'].dt.time
 
-    # 時間、職種、雇用形態ごとに勤務人数を集計
-    grouped_counts = df.groupby(
-        ['time_group', '職種', '雇用形態']
+    # 日付ごとに時間帯・職種・雇用形態別の実績人数を算出
+    daily_counts = df.groupby(
+        [df['time_group'].dt.date.rename('date'), 'time_of_day', '職種', '雇用形態']
     ).size().reset_index(name='actual_count')
 
-    # 各グループにおける人数の統計分布から、3つのNeed値を一括で計算
-    needs_df = grouped_counts.groupby(['職種', '雇用形態', 'time_group'])['actual_count'].agg(
+    # 時間帯ごとに歴史的なNeed値を計算
+    needs_by_time = daily_counts.groupby(['time_of_day', '職種', '雇用形態'])['actual_count'].agg(
         need_mean='mean',
         need_median='median',
         need_p25=lambda x: x.quantile(0.25)
     ).reset_index()
+
+    # 全てのタイムスロットにNeed値を紐付け
+    all_slots = df[['time_group', 'time_of_day', '職種', '雇用形態']].drop_duplicates()
+    needs_df = pd.merge(
+        all_slots,
+        needs_by_time,
+        on=['time_of_day', '職種', '雇用形態'],
+        how='left'
+    ).drop(columns=['time_of_day'])
+
+    # Need列の欠損を0で補完
+    needs_df[['need_mean', 'need_median', 'need_p25']] = needs_df[
+        ['need_mean', 'need_median', 'need_p25']
+    ].fillna(0)
 
     return needs_df


### PR DESCRIPTION
## Summary
- Calculate statistical needs across dates by time of day and map to each time slot
- Include actual_count when merging shortage values into actual records
- Remove duplicate rows when displaying scenario shortages in the UI

## Testing
- `pytest` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a2c0e325048333b24f96a9b05bbf05